### PR TITLE
Use latest Node on CI since the old version doesn't support package-l…

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -9,19 +9,15 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
-
-    strategy:
-      matrix:
-        node-version: [14.x]        
+    runs-on: windows-latest   
 
     steps:
     - uses: browser-actions/setup-chrome@latest
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+    - uses: actions/checkout@v4
+    - name: Use latest Node.js
+      uses: actions/setup-node@v3
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: latest
     - run: npm ci
     - run: npm i -g karma
     - run: npm i -g cat


### PR DESCRIPTION
### Motivation

Should fix the pipeline. It was broken since the packages got updated in https://github.com/kontent-ai/backup-manager-js/commit/05f1270395f2dcbc076b6bf7c4f50f29bfc252af, because with the package updates the package-lock was generated in the latest version (v3) which is not supported by npm@6 that gets installed with node@14 that was used on the CI. This PR changes the CI to use the latest (`lts`) version of the node so this problem should not repeat in the future.
